### PR TITLE
Update homepage link

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
             "role":"Developer"
         }
     ],
-    "homepage": "https://github.com/plenta/contao-tootlip-bundle",
+    "homepage": "https://github.com/plenta/contao-tooltip-bundle",
     "support":{
         "issues":"https://github.com/plenta/contao-tooltip-bundle/issues",
         "source":"https://github.com/plenta/contao-tooltip-bundle"


### PR DESCRIPTION
There is a small typo in the homepage link which led to a 404 when opening it via [extensions.contao.org](https://extensions.contao.org/?q=&pages=1&p=plenta%2Fcontao-tooltip-bundle)

https://github.com/plenta/contao-tootlip-bundle